### PR TITLE
Add new option -a <AUTH_HEADER>, --auth-header <AUTH_HEADER> to specify an authorization bearer

### DIFF
--- a/LFIDump.py
+++ b/LFIDump.py
@@ -62,7 +62,7 @@ def parseArgs():
 
     parser.add_argument("-D", "--dump-dir", dest="dump_dir", action="store", type=str, default="./loot/", required=False, help="Directory where the dumped files will be stored.")
     parser.add_argument("-k", "--insecure", dest="insecure_tls", action="store_true", default=False, help="Allow insecure server connections when using SSL (default: False)")
-    parser.add_argument("--auth-header", dest="auth_header", action="store", type=str, required=False, help="Authorization header value (Bearer token).")
+    parser.add_argument("-a", "--auth-header", dest="auth_header", action="store", type=str, required=False, help="Authorization header value (Bearer token).")
 
     return parser.parse_args()
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
  - [x] Dump lots of files from a wordlist with `-F /path/to/local/wordlist.txt`
  - [x] Insecure mode (for broken SSL/TLS) with `-k/--insecure`
  - [x] Custom local dump dir with `-d/--dump-dir`
+ - [x] Specify authorization header with `-a/--auth-header`
 
 ## Usage
 
@@ -38,6 +39,8 @@ optional arguments:
   -D DUMP_DIR, --dump-dir DUMP_DIR
                         Directory where the dumped files will be stored.
   -k, --insecure        Allow insecure server connections when using SSL (default: False)
+  -a AUTH_HEADER, --auth-header AUTH_HEADER
+                        Authorization header value (Bearer token).
 ```
 
 ## Examples


### PR DESCRIPTION
Added new option `-a <AUTH_HEADER>` / `--auth-header <AUTH_HEADER>` to specify an authorization bearer token for HTTP auth.

The supplied `AUTH_HEADER` will be used via the `Authorization` HTTP header in HTTP requests like so:
`Authorization: Bearer <AUTH_HEADER>`